### PR TITLE
fix: probes

### DIFF
--- a/.socialgouv/config.json
+++ b/.socialgouv/config.json
@@ -18,13 +18,13 @@
   },
   "probes": {
     "livenessProbe": {
-      "timeoutDelay": 10
+      "timeoutSeconds": 10
     },
     "readinessProbe": {
-      "timeoutDelay": 10
+      "timeoutSeconds": 10
     },
     "startupProbe": {
-      "timeoutDelay": 10
+      "timeoutSeconds": 10
     }
   }
 }


### PR DESCRIPTION
my bad :/

cette fois-ci j'ai vérifié et c'est bon pour les sondes.

le nombre de replica (pod) est toujours à 1 par défaut par contre donc il faut pour l'instant l'augmenter à la main via rancher ou k9s (editer le deploiement)