### PR TITLE
refactor: use swc instead of babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/jest.config-api.js
+++ b/jest.config-api.js
@@ -1,8 +1,12 @@
-module.exports = {
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest();
+
+module.exports = createJestConfig({
   globalSetup: "<rootDir>jest/api-setup.js",
   globalTeardown: "<rootDir>jest/api-teardown.js",
   testPathIgnorePatterns: ["<rootDir>/.next/", "<rootDir>/node_modules/"],
   testMatch: ["**/*.spec.ts"],
   moduleDirectories: ["<rootDir>", "node_modules"],
   testTimeout: 30000,
-};
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,12 @@
-module.exports = {
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest();
+
+module.exports = createJestConfig({
   testMatch: ["**/*.spec.ts"],
   testPathIgnorePatterns: ["<rootDir>/src/__tests__/api"],
   moduleDirectories: ["<rootDir>", "node_modules"],
   testTimeout: 30000
-};
+});
+
+


### PR DESCRIPTION
More info here: https://nextjs.org/docs/advanced-features/compiler

Edit: en fait ça semble dangereux, car par exemple ça prend le .env de base quand on lance les tests en local