### PR TITLE
fix(admin): allow empty languages

### DIFF
--- a/src/__tests__/psychologists-update.spec.ts
+++ b/src/__tests__/psychologists-update.spec.ts
@@ -111,4 +111,23 @@ describe("updateIfExists", () => {
     // @ts-ignore
     expect(updatedPsy.shouldBeIgnored).toEqual(undefined);
   });
+
+  it("should empty languages when languages is empty", async () => {
+    async function expectUpdatedPsy(expected) {
+      const updatedPsy = (await models.Psychologist.findOne({
+        where: { email: valideInput.email },
+      })) as unknown as Psychologist;
+      expect(updatedPsy.languages).toEqual(expected);
+    }
+    getAddressCoordinatesStub.returns({ latitude: 456, longitude: 123 });
+    // Should add language.
+    await updateIfExists("1", "01", { ...valideInput, languages: "anglais" });
+    await expectUpdatedPsy("anglais");
+    // Should not alter language when nothing is provided.
+    await updateIfExists("1", "01", valideInput);
+    await expectUpdatedPsy("anglais");
+    // Should empty language when empty string is provided.
+    await updateIfExists("1", "01", { ...valideInput, languages: "" });
+    await expectUpdatedPsy(null);
+  });
 });

--- a/src/pages/api/admin/psychologists/[id].ts
+++ b/src/pages/api/admin/psychologists/[id].ts
@@ -21,7 +21,7 @@ const updateSchema = Joi.object({
   displayEmail: Joi.boolean().required(),
   email: Joi.string().email(),
   firstName: Joi.string().required(),
-  languages: Joi.string().allow(null),
+  languages: Joi.string().allow("", null),
   lastName: Joi.string().required(),
   phone: Joi.string().required(),
   displayPhone: Joi.boolean().required(),

--- a/src/services/__tests__/ds-parse-psychologists.spec.ts
+++ b/src/services/__tests__/ds-parse-psychologists.spec.ts
@@ -106,11 +106,11 @@ describe("parseDossierMetadata", () => {
   it.each`
     languages                       | languagesOther | resultValue
     ${undefined}                    | ${undefined}   | ${undefined}
-    ${null}                         | ${undefined}   | ${undefined}
-    ${""}                           | ${undefined}   | ${undefined}
+    ${null}                         | ${undefined}   | ${null}
+    ${""}                           | ${undefined}   | ${null}
     ${undefined}                    | ${"Francais"}  | ${undefined}
-    ${null}                         | ${"Francais"}  | ${undefined}
-    ${""}                           | ${"Francais"}  | ${undefined}
+    ${null}                         | ${"Francais"}  | ${null}
+    ${""}                           | ${"Francais"}  | ${null}
     ${"FRANCAIS"}                   | ${undefined}   | ${undefined}
     ${"Francais"}                   | ${undefined}   | ${undefined}
     ${"francais"}                   | ${undefined}   | ${undefined}

--- a/src/services/format-psychologists.ts
+++ b/src/services/format-psychologists.ts
@@ -28,7 +28,7 @@ function formatFirstName(string) {
 }
 
 export const formatLanguage = (value) => {
-  if (!value) return;
+  if (!value) return null;
   const cleanFrench = value.trim().replace(frenchWord, "");
   return cleanFrench || undefined;
 };

--- a/src/services/format-psychologists.ts
+++ b/src/services/format-psychologists.ts
@@ -28,6 +28,7 @@ function formatFirstName(string) {
 }
 
 export const formatLanguage = (value) => {
+  if (value === undefined) return;
   if (!value) return null;
   const cleanFrench = value.trim().replace(frenchWord, "");
   return cleanFrench || undefined;


### PR DESCRIPTION
admin : allow empty languages

même avec ce change, on ne peut pas RAZ un champ 'languages'; si on le vide puis submit, il reste rempli au reload