### PR TITLE
refactor: replace sequelize by prisma (do not merge)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "jest-dev-server": "^6.0.3",
     "lint-staged": "^13.0.0",
     "prettier": "^2.5.1",
+    "prisma": "^4.0.0",
     "sinon": "^14.0.0",
     "typescript": "^4.5.5",
     "typescript-eslint": "^0.0.1-alpha.0"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,35 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Psychologist {
+  id                       Int                                   @id
+  firstName                String                                @db.VarChar(255)
+  lastName                 String                                @db.VarChar(255)
+  email                    String?                               @db.VarChar(255)
+  displayEmail             Boolean
+  public                   String                                @db.VarChar(255)
+  archived                 Boolean
+  address                  String
+  secondAddress            String?
+  department               String                                @db.VarChar(255)
+  phone                    String                                @db.VarChar(255)
+  website                  String?
+  cdsmsp                   String?                               @db.VarChar(255)
+  languages                String?                               @db.VarChar(255)
+  teleconsultation         Boolean
+  coordinates              Unsupported("geometry(Point, 4326)")?
+  secondAddressCoordinates Unsupported("geometry(Point, 4326)")?
+  createdAt                DateTime                              @default(now())
+  updatedAt                DateTime                              @updatedAt
+  visible                  Boolean?                              @default(true)
+  state                    String                                @db.VarChar(255)
+  displayPhone             Boolean?                              @default(true)
+  addressAdditional        String?
+  secondAddressAdditional  String?
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -923,6 +923,11 @@
   resolved "https://registry.yarnpkg.com/@panva/hkdf/-/hkdf-1.0.2.tgz#bab0f09d09de9fd83628220d496627681bc440d6"
   integrity sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==
 
+"@prisma/engines@3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11":
+  version "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
+  resolved "https://registry.yarnpkg.com/@prisma/engines/-/engines-3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11.tgz#82f0018153cffa05d61422f9c0c7b0479b180f75"
+  integrity sha512-u/rG4lDHALolWBLr3yebZ+N2qImp3SDMcu7bHNJuRDaYvYEXy/MqfNRNEgd9GoPsXL3gofYf0VzJf2AmCG3YVw==
+
 "@react-leaflet/core@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@react-leaflet/core/-/core-2.0.0.tgz#212f4d87dc7681f40ca0e47d99672676c20c8ef6"
@@ -5647,6 +5652,13 @@ pretty-format@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
   integrity sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==
+
+prisma@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/prisma/-/prisma-4.0.0.tgz#4ddb8fcd4f64d33aff8c198a6986dcce66dc8152"
+  integrity sha512-Dtsar03XpCBkcEb2ooGWO/WcgblDTLzGhPcustbehwlFXuTMliMDRzXsfygsgYwQoZnAUKRd1rhpvBNEUziOVw==
+  dependencies:
+    "@prisma/engines" "3.16.0-49.da41d2bb3406da22087b849f0e911199ba4fbf11"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"


### PR DESCRIPTION
Sequelize vieillit et utilise des librairies plus maintenues (moment par exemple) en sombrant lui-même dans l'obsolescence (voir leur page sur le Typescript par exemple qui est un aveu d'échec). On a des `@ts-ignore` à plusieurs endroits qui polluent le code et la review. Prisma est le new cool kid, on peut parier dessus pour les quelques prochaines années sans trop de risques à migrer

Cependant il y a plusieurs problèmes à faire une migration : 
 - ça a un coût de migration (https://www.prisma.io/docs/guides/migrate-to-prisma/migrate-from-sequelize)
 - postgis est encore mal supporté (un point pour sequelize !)
 - pas d'apport produit évident

Je laisse cette PR (j'avais 10 minutes à tuer hier soir) qui ne fonctionne pas pour discussion (elle peut être fermée sans problème et sans discussion bien sûr !)