### PR TITLE
feat(cron): check nir duplicates on import and add a script to check duplicates manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "cy:run": "cypress run",
     "cron:launch": "ts-node --transpile-only src/cron/launch.ts",
     "script:extract-departments": "ts-node --transpile-only scripts/stats-departements.ts",
-    "script:extract-emails-acceptes": "ts-node --transpile-only scripts/extract-emails-acceptes.ts"
+    "script:extract-emails-acceptes": "ts-node --transpile-only scripts/extract-emails-acceptes.ts",
+    "script:get-duplicate-nirs": "ts-node --transpile-only scripts/get-duplicate-nirs.ts"
   }
 }

--- a/scripts/get-duplicate-nirs.ts
+++ b/scripts/get-duplicate-nirs.ts
@@ -1,0 +1,19 @@
+import { getNIRs } from "../src/services/demarchesSimplifiees/import";
+
+(async () => {
+  const { NIRs } = await getNIRs();
+  const lookup = NIRs.reduce((a, e) => {
+    a[e.champs[0].stringValue] = ++a[e.champs[0].stringValue] || 0;
+    return a;
+  }, {});
+  const duplicates = NIRs.filter((e) => lookup[e.champs[0].stringValue]);
+  console.log("List of duplicates NIR:");
+  for (const duplicate of duplicates) {
+    console.log(
+      "NIR",
+      duplicate.champs[0].stringValue,
+      "dossier",
+      duplicate.number
+    );
+  }
+})();

--- a/src/__tests__/cron/validate-dossier.spec.ts
+++ b/src/__tests__/cron/validate-dossier.spec.ts
@@ -141,4 +141,55 @@ describe("validateDossier", () => {
     expect(getAddressCoordinates).toHaveBeenCalledTimes(2);
     expect(errors).toStrictEqual([]);
   });
+
+  it("should return error when nir already exists", async () => {
+    const errors = await validateDossier(
+      {
+        ...psy,
+        nir: "1234567890123",
+      } as ParsedDSPsychologist,
+      adeliData as AdeliData[],
+      [{ id: 12345, value: "1234567890123" }]
+    );
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("numéro de sécurité sociale"),
+      ])
+    );
+  });
+
+  it("should not return error when nir already exists for same Psychologist", async () => {
+    const errors = await validateDossier(
+      {
+        ...psy,
+        nir: "1234567890123",
+      } as ParsedDSPsychologist,
+      adeliData as AdeliData[],
+      [{ id: 1, value: "1234567890123" }]
+    );
+    expect(errors).toEqual(
+      expect.not.arrayContaining([
+        expect.stringContaining("numéro de sécurité sociale"),
+      ])
+    );
+  });
+
+  it("should not return error when nir does not exists", async () => {
+    const errors = await validateDossier(
+      {
+        ...psy,
+        nir: "1234567890123",
+      } as ParsedDSPsychologist,
+      adeliData as AdeliData[],
+      [
+        { id: 123, value: "123" },
+        { id: 456, value: "456" },
+      ]
+    );
+    expect(errors).toEqual(
+      expect.not.arrayContaining([
+        expect.stringContaining("numéro de sécurité sociale"),
+      ])
+    );
+  });
 });

--- a/src/__tests__/cron/validate-dossier.spec.ts
+++ b/src/__tests__/cron/validate-dossier.spec.ts
@@ -1,7 +1,7 @@
 import { validateDossier } from "../../cron/demarchesSimplifiees";
 import getAddressCoordinates from "../../services/getAddressCoordinates";
 import { AdeliData } from "../../types/adeli";
-import { ParsedDSPsychologist, Psychologist } from "../../types/psychologist";
+import { ParsedDSPsychologist } from "../../types/psychologist";
 
 jest.mock("../../services/getAddressCoordinates");
 

--- a/src/__tests__/cron/validate-dossier.spec.ts
+++ b/src/__tests__/cron/validate-dossier.spec.ts
@@ -1,12 +1,12 @@
 import { validateDossier } from "../../cron/demarchesSimplifiees";
 import getAddressCoordinates from "../../services/getAddressCoordinates";
 import { AdeliData } from "../../types/adeli";
-import { Psychologist } from "../../types/psychologist";
+import { ParsedDSPsychologist, Psychologist } from "../../types/psychologist";
 
 jest.mock("../../services/getAddressCoordinates");
 
 describe("validateDossier", () => {
-  const psy: Partial<Psychologist> = {
+  const psy: Partial<ParsedDSPsychologist> = {
     id: 1,
     firstName: "John",
     lastName: "Doe",
@@ -23,7 +23,7 @@ describe("validateDossier", () => {
     },
   ];
   it("should return one error when adeliData is missing", async () => {
-    const errors = await validateDossier(psy as Psychologist, []);
+    const errors = await validateDossier(psy as ParsedDSPsychologist, []);
     expect(errors).toStrictEqual(["Numéro ADELI invalide : 44123456789"]);
   });
 
@@ -32,7 +32,7 @@ describe("validateDossier", () => {
       {
         ...psy,
         department: "35",
-      } as Psychologist,
+      } as ParsedDSPsychologist,
       adeliData as AdeliData[]
     );
     expect(errors).toEqual(
@@ -52,7 +52,7 @@ describe("validateDossier", () => {
       {
         ...psy,
         address: "test",
-      } as Psychologist,
+      } as ParsedDSPsychologist,
       adeliData as AdeliData[]
     );
 
@@ -78,7 +78,7 @@ describe("validateDossier", () => {
         ...psy,
         address: "valid",
         secondAddress: "invalid",
-      } as Psychologist,
+      } as ParsedDSPsychologist,
       adeliData as AdeliData[]
     );
     expect(getAddressCoordinates).toHaveBeenCalledTimes(2);
@@ -110,7 +110,7 @@ describe("validateDossier", () => {
       {
         ...psy,
         website: input,
-      } as Psychologist,
+      } as ParsedDSPsychologist,
       adeliData as AdeliData[]
     );
     expect(errors).toEqual(
@@ -135,7 +135,7 @@ describe("validateDossier", () => {
         address: "valid",
         secondAddress: "valid",
         email: "test@example.org",
-      } as Psychologist,
+      } as ParsedDSPsychologist,
       adeliData as AdeliData[]
     );
     expect(getAddressCoordinates).toHaveBeenCalledTimes(2);

--- a/src/cron/demarchesSimplifiees.ts
+++ b/src/cron/demarchesSimplifiees.ts
@@ -115,7 +115,9 @@ export const validateDossier = async (
   }
 
   if (dossier.nir) {
-    const nirAlreadyUsed = NIRs.find((nir) => nir.value === dossier.nir);
+    const nirAlreadyUsed = NIRs.find(
+      (nir) => nir.value === dossier.nir && nir.id !== dossier.id
+    );
     if (nirAlreadyUsed) {
       errors.push(
         `Le numéro de sécurité sociale ${dossier.nir} est déjà utilisé pour le dossier ${nirAlreadyUsed.id}`

--- a/src/db/seeds/psychologist.ts
+++ b/src/db/seeds/psychologist.ts
@@ -62,7 +62,6 @@ export const getOnePsychologist = (
     email: faker.internet.exampleEmail(),
     firstName: faker.name.firstName(),
     id: faker.datatype.number({ max: 2147483647 }),
-    adeliId: faker.phone.phoneNumber("## ## ## ## ##"),
     languages: faker.helpers.arrayElement(languages),
     lastName: faker.name.lastName(),
     phone: faker.phone.phoneNumber("0# ## ## ## ##"),

--- a/src/services/__tests__/ds-parse-psychologists.spec.ts
+++ b/src/services/__tests__/ds-parse-psychologists.spec.ts
@@ -24,6 +24,11 @@ describe("parseDossierMetadata", () => {
         label: "Faites-vous de la téléconsultation ?",
         stringValue: "true",
       },
+      {
+        id: "Q2hhbXAtMjM0NjQzNQ==",
+        label: "Numéro de sécurité sociale (NIR)", // This is not the real label.
+        stringValue: "123456",
+      },
     ],
     demandeur: { nom: "Smith", prenom: "Anne" },
     groupeInstructeur: { id: "31", label: "31 - Haute-Garonne" },
@@ -38,6 +43,7 @@ describe("parseDossierMetadata", () => {
     expect(result).toEqual({
       address: "12 Rue Neuve 31000 Toulouse",
       demarcheSimplifieesId: "1",
+      nir: "123456",
       archived: false,
       department: "31",
       displayEmail: false,

--- a/src/services/demarchesSimplifiees/parse-psychologists.ts
+++ b/src/services/demarchesSimplifiees/parse-psychologists.ts
@@ -1,4 +1,8 @@
-import { DSPsychologist, Psychologist } from "../../types/psychologist";
+import {
+  DSPsychologist,
+  ParsedDSPsychologist,
+  Psychologist,
+} from "../../types/psychologist";
 import config from "../config";
 import { formatLanguage } from "../format-psychologists";
 
@@ -7,6 +11,7 @@ const extractDepartmentNumber = (dep: string): string => {
 };
 const CHAMPS = JSON.parse(config.demarchesSimplifiees.champs);
 const CHAMP_LANGUAGE_OTHER = "Q2hhbXAtMjM0NjQzNA==";
+export const CHAMP_NIR = "Q2hhbXAtMjM0NjQzNQ==";
 
 const PARSERS = {
   displayEmail: (value) => value === "true",
@@ -32,8 +37,10 @@ const addOtherLanguages = (
   }
 };
 
-export const parseDossierMetadata = (dossier: DSPsychologist): Psychologist => {
-  const psychologist: Partial<Psychologist> = {
+export const parseDossierMetadata = (
+  dossier: DSPsychologist
+): ParsedDSPsychologist => {
+  const psychologist: Partial<ParsedDSPsychologist> = {
     demarcheSimplifieesId: dossier.id,
     archived: dossier.archived,
     department: extractDepartmentNumber(dossier.groupeInstructeur.label),
@@ -41,6 +48,7 @@ export const parseDossierMetadata = (dossier: DSPsychologist): Psychologist => {
     id: dossier.number,
     lastName: dossier.demandeur.nom,
     state: dossier.state,
+    nir: getDossierChamp(dossier, CHAMP_NIR)?.stringValue?.trim(),
   };
 
   CHAMPS.forEach(([id, field]) => {
@@ -52,10 +60,12 @@ export const parseDossierMetadata = (dossier: DSPsychologist): Psychologist => {
   });
   addOtherLanguages(dossier, psychologist);
 
-  return psychologist as Psychologist;
+  return psychologist as ParsedDSPsychologist;
 };
 
-const parseDossiers = (dsPsychologists: DSPsychologist[]): Psychologist[] => {
+const parseDossiers = (
+  dsPsychologists: DSPsychologist[]
+): ParsedDSPsychologist[] => {
   console.log(`Parsing ${dsPsychologists.length} psychologists from DS API`);
   return dsPsychologists.map((dsPsychologist) =>
     parseDossierMetadata(dsPsychologist)

--- a/src/types/demarcheSimplifiee.d.ts
+++ b/src/types/demarcheSimplifiee.d.ts
@@ -11,3 +11,22 @@ export interface DSResponse {
     };
   };
 }
+
+export interface DSResponseNIRNode {
+  number: number;
+  champs: {
+    stringValue: string;
+  }[];
+}
+
+export interface DSResponseNIR {
+  demarche: {
+    dossiers: {
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string;
+      };
+      nodes: DSResponseNIRNode[];
+    };
+  };
+}

--- a/src/types/psychologist.d.ts
+++ b/src/types/psychologist.d.ts
@@ -24,12 +24,17 @@ export interface Psychologist {
   secondAddressCoordinates: CoordinatesPostgis;
   department: string;
   state: string;
-  adeliId: string;
-  demarcheSimplifieesId?: string;
   // These two parameters are dynamically generated
   // by API when querying via latitude and longitude.
   distance?: number;
   distanceBasedOn?: DistanceBasedOn;
+}
+
+// These values are only used for check purpose (from DS), and should not be imported.
+export interface ParsedDSPsychologist extends Psychologist {
+  nir: string;
+  adeliId: string;
+  demarcheSimplifieesId: string;
 }
 
 export interface DSPsychologist {


### PR DESCRIPTION
_Le formatage/parsing/import/check étant imbriqué et en même temps éclaté, c'était difficile de faire simple, j'espère ne pas avoir trop rajouté de complexité. Je pense que je proposerai un refacto de ces parties un jour, mais dans une autre PR._

NIR = Numéro de sécurité sociale (source : https://www.ameli.fr/assure/droits-demarches/principes/numero-securite-sociale)

- Ajout d'un script `yarn script:get-duplicate-nirs` pour afficher tous les doublons de NIR actuellement dans la base.
- J'ai essayé de séparé le `Psychologist` tel qu'on l'a dans notre base de données de celui qu'on a parsé depuis DS et qui contient des infos qui ne doivent pas être sauvegardées: adeliId, demarcheSimplifieId, NIR (d'où le `ParsedDSPsychologist`). Ça permet de défaire ce `Psychologist` qui gagnait en complexité et devenait fourre-tout.
- L'objectif premier de cette pr reste d'afficher dans le dossier `Le numéro de sécurité sociale xxxx est déjà utilisé pour le dossier yyyy`
- J'ai essayé de faire la requête graphQL `requestNIR` la plus légère possible pour ne pas transporter trop de données. On ajoute quand même 50 secondes à chaque `verifDossier`. 

À ta dispo @carolineBda pour discuter de tout ça.