### PR TITLE
feat(reportingTraitementErrone): add check for all dossiers acceptés without being eligible or notified

### DIFF
--- a/src/__tests__/cron/reportingTraitementErrone.spec.ts
+++ b/src/__tests__/cron/reportingTraitementErrone.spec.ts
@@ -1,5 +1,6 @@
 import {
   cpamOnly,
+  notEligibleAccepted,
   notificationSelectionNotChecked,
   withoutInstructeurFB,
 } from "../../cron/reportingTraitementErrone";
@@ -129,6 +130,7 @@ describe("Cron import from DS", () => {
       ]);
       expect(await notificationSelectionNotChecked()).toHaveLength(0);
     });
+
     it("should include dossiers with notification selection not checked and dossier elligible OUI or NON", async () => {
       mockDSCall([
         {
@@ -163,6 +165,54 @@ describe("Cron import from DS", () => {
         },
       ]);
       expect(await notificationSelectionNotChecked()).toHaveLength(2);
+    });
+  });
+
+  describe("`notEligibleAccepted()`: dossiers accepted but not marked as eligible", () => {
+    it("should filter out dossiers elligible = OUI", async () => {
+      mockDSCall([
+        {
+          id: "1",
+          annotations: [
+            {
+              id: DOSSIER_ELIGIBLE,
+              label: "Dossier elligible",
+              stringValue: "oui",
+            },
+          ],
+        },
+      ]);
+      expect(await notEligibleAccepted()).toHaveLength(0);
+    });
+
+    it("should include dossiers dossier elligible !== OUI", async () => {
+      mockDSCall([
+        {
+          id: "1",
+          annotations: [],
+        },
+        {
+          id: "2",
+          annotations: [
+            {
+              id: DOSSIER_ELIGIBLE,
+              label: "Dossier elligible",
+              stringValue: "NON",
+            },
+          ],
+        },
+        {
+          id: "2",
+          annotations: [
+            {
+              id: DOSSIER_ELIGIBLE,
+              label: "Dossier elligible",
+              stringValue: "quelque chose",
+            },
+          ],
+        },
+      ]);
+      expect(await notEligibleAccepted()).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
Ajout d'un 4eme check pour les dossiers erronés :
des dossiers acceptés ni coché “éligible” et/ou ni cochés “notifiés éligibles”